### PR TITLE
Update the PHPStan usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Include all stubs in PHPStan configuration file.
 
 ```yaml
 parameters:
-    bootstrapFiles:
-        - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
-        - %rootDir%/../../php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
+    scanFiles:
+        - vendor/php-stubs/wordpress-tests-stubs/wordpress-stubs.php
+        - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Include all stubs in PHPStan configuration file.
 ```yaml
 parameters:
     scanFiles:
-        - vendor/php-stubs/wordpress-tests-stubs/wordpress-stubs.php
-        - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
+        - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
+        - %rootDir%/../../php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
 ```


### PR DESCRIPTION
In order to properly discover symbols, the stub files should be added to [`scanFiles`](https://phpstan.org/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies) (e.g. "consider the definitions from these files"), not [`bootstrapFiles`](https://phpstan.org/config-reference#bootstrap) (which actually executes the files).

Adding the stubs to `bootstrapFiles` will cause errors like the following:

> **Fatal error:**  Cannot redeclare wp_cache_add() (previously declared in /path/to/project/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php:88572) in /path/to/project/vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php on line 4319